### PR TITLE
chore: add read-only support

### DIFF
--- a/dev/src/components/ConnectWallet.tsx
+++ b/dev/src/components/ConnectWallet.tsx
@@ -2,33 +2,65 @@ import {
   RenderWallet,
   RenderWalletPeerConnect,
   RenderWalletState,
-  TSupportedWalletExtensions,
   useAvailableExtensions,
 } from "@sundaeswap/wallet-lite";
 import classNames from "classnames";
-import { FC } from "react";
+import { FC, useState } from "react";
 
 export const ConnectWallet: FC = () => {
   const availableExtensions = useAvailableExtensions();
+  const [selectedWallet, setSelectedWallet] = useState<string>();
+  const [customWallet, setCustomWallet] = useState<string>();
 
   return (
     <div className="m-4 w-1/4 border border-gray-400 p-4 flex flex-col">
       <RenderWallet
-        render={({ activeWallet, connectWallet }) => {
+        render={({ connectWallet }) => {
           return (
-            <select
-              value={activeWallet || "default"}
-              onChange={async ({ target }) => {
-                await connectWallet(target.value as TSupportedWalletExtensions);
-              }}
-            >
-              <option value={"default"}>Select A Wallet</option>
-              {availableExtensions.map(({ name, property }) => (
-                <option key={property} value={property}>
-                  Connect {name}
-                </option>
-              ))}
-            </select>
+            <div className="flex items-center justify-between gap-2 flex-wrap">
+              <select
+                className="w-1/2"
+                value={selectedWallet || "default"}
+                onChange={async ({ target }) => {
+                  setCustomWallet(undefined);
+                  setSelectedWallet(target.value);
+                }}
+              >
+                <option value={"default"}>Select A Wallet</option>
+                {availableExtensions.map(({ name, property }) => (
+                  <option key={property} value={property}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+              <input
+                className="w/1-2"
+                placeholder="Read-only address..."
+                type="text"
+                onChange={(e) => setCustomWallet(e.target.value)}
+                value={customWallet}
+              />
+              <button
+                className={classNames(
+                  {
+                    "text-gray-400 cursor-not-allowed":
+                      !selectedWallet && !customWallet,
+                  },
+                  {
+                    "text-white cursor-pointer": selectedWallet || customWallet,
+                  },
+                  "w-full ml-auto bg-black px-4 py-2",
+                )}
+                disabled={!selectedWallet && !customWallet}
+                onClick={() => {
+                  if (selectedWallet || customWallet) {
+                    connectWallet((selectedWallet || customWallet) as string);
+                  }
+                }}
+              >
+                Connect Wallet
+              </button>
+            </div>
           );
         }}
       />

--- a/lib/src/classes/CustomWalletApi.class.ts
+++ b/lib/src/classes/CustomWalletApi.class.ts
@@ -1,0 +1,54 @@
+import { Cardano } from "@cardano-sdk/core";
+import { Cip30WalletApi } from "@cardano-sdk/dapp-connector";
+
+export class CustomWalletApi implements Cip30WalletApi {
+  constructor(public address: string) {}
+
+  getBalance = async () => {
+    throw new Error("not implemented");
+  };
+
+  getChangeAddress = async () => {
+    return Cardano.Address.fromBech32(this.address).toBytes().toString();
+  };
+
+  getCollateral = async () => {
+    return [];
+  };
+
+  getExtensions = async () => {
+    return [];
+  };
+
+  getNetworkId = async () => {
+    return this.address.startsWith("addr_test") ? 0 : 1;
+  };
+
+  getRewardAddresses = async () => {
+    return [];
+  };
+
+  getUnusedAddresses = async () => {
+    return [];
+  };
+
+  getUsedAddresses = async () => {
+    return [Cardano.Address.fromBech32(this.address).toBytes().toString()];
+  };
+
+  getUtxos = async () => {
+    return [];
+  };
+
+  signData = async () => {
+    throw new Error("not implemented");
+  };
+
+  signTx = async () => {
+    throw new Error("not implemented");
+  };
+
+  submitTx = async () => {
+    throw new Error("not implemented");
+  };
+}


### PR DESCRIPTION
This allows you to "mock" a connection to a wallet simply by inputing the bech32 address in the `connectWallet("addr...")` method. Limited functionality, but allows a user to connect "as a user" without actually having any data for that user.