### PR TITLE
fix(observer): metadata cache, utxo re-render churn, and balance-commit hardening

### DIFF
--- a/lib/src/classes/WalletObserver.class.ts
+++ b/lib/src/classes/WalletObserver.class.ts
@@ -67,6 +67,10 @@ export class WalletObserver<
   private _lastUnusedAddresses: string[] | null = null;
   private _lastChangeAddressCbor: string | null = null;
   private _lastChangeAddress: string | null = null;
+  private _lastUtxosCbor: string[] | null = null;
+  private _lastUtxos: TransactionUnspentOutput[] | undefined = undefined;
+  private _lastCollateralCbor: string[] | null = null;
+  private _lastCollateral: TransactionUnspentOutput[] | undefined = undefined;
 
   // AbortController for cancelling in-flight metadata fetches when metadataResolver changes
   private _metadataAbortController: AbortController | null = null;
@@ -493,6 +497,10 @@ export class WalletObserver<
     this._lastUnusedAddresses = null;
     this._lastChangeAddressCbor = null;
     this._lastChangeAddress = null;
+    this._lastUtxosCbor = null;
+    this._lastUtxos = undefined;
+    this._lastCollateralCbor = null;
+    this._lastCollateral = undefined;
   };
 
   disconnect = (): void => {
@@ -789,6 +797,22 @@ export class WalletObserver<
       return e as Error;
     }
 
+    // Return the cached, already-parsed array when the raw CBOR is unchanged.
+    // This preserves referential equality across syncs (so unchanged UTxOs
+    // don't churn consumer re-renders) and skips redundant deserialization.
+    if (
+      cbor &&
+      this._lastUtxosCbor &&
+      this._lastUtxos &&
+      cbor.length === this._lastUtxosCbor.length &&
+      cbor.every((v, i) => v === this._lastUtxosCbor![i])
+    ) {
+      if (this._options.debug) {
+        console.log(`getUtxos (cached): ${performance.now() - start}ms`);
+      }
+      return this._lastUtxos;
+    }
+
     const data = cbor?.map((val) => {
       const txOutput = Serialization.TransactionUnspentOutput.fromCbor(
         typedHex(val),
@@ -799,6 +823,9 @@ export class WalletObserver<
       txOutput.output = txOutput.output.bind(txOutput);
       return txOutput;
     });
+
+    this._lastUtxosCbor = cbor;
+    this._lastUtxos = data;
 
     const end = performance.now();
     if (this._options.debug) {
@@ -868,6 +895,21 @@ export class WalletObserver<
       return e as Error;
     }
 
+    // Return the cached, already-parsed array when the raw CBOR is unchanged
+    // (mirrors getUtxos — preserves referential equality, skips re-parsing).
+    if (
+      cbor &&
+      this._lastCollateralCbor &&
+      this._lastCollateral &&
+      cbor.length === this._lastCollateralCbor.length &&
+      cbor.every((v, i) => v === this._lastCollateralCbor![i])
+    ) {
+      if (this._options.debug) {
+        console.log(`getCollateral (cached): ${performance.now() - start}ms`);
+      }
+      return this._lastCollateral;
+    }
+
     const data = cbor?.map((val) => {
       const txOutput = Serialization.TransactionUnspentOutput.fromCbor(
         typedHex(val),
@@ -878,6 +920,9 @@ export class WalletObserver<
       txOutput.output = txOutput.output.bind(txOutput);
       return txOutput;
     });
+
+    this._lastCollateralCbor = cbor;
+    this._lastCollateral = data;
 
     const end = performance.now();
     if (this._options.debug) {

--- a/lib/src/classes/WalletObserver.class.ts
+++ b/lib/src/classes/WalletObserver.class.ts
@@ -899,20 +899,27 @@ export class WalletObserver<
   ): Promise<Map<string, AssetMetadata>> => {
     const start = performance.now();
 
-    if (this._cachedMetadata) {
-      const cachedKeys = new Set(this._cachedMetadata.keys());
-      const inputKeys = new Set(assetIds);
+    // Normalize once so the cache lookup and the resolver call share the same
+    // (dotted) key format. Asset ids arrive here straight from
+    // `data.multiasset().keys()`, which are dotless (`policyId + assetName`),
+    // while the resolver stores its results under dotted keys. Comparing the
+    // two formats directly meant the cache never hit for any wallet holding a
+    // native asset, so the full metadata set was refetched on every balance
+    // change.
+    const normalizedIds = assetIds.map(normalizeAssetIdWithDot);
 
-      if (
-        cachedKeys.size === inputKeys.size &&
-        [...cachedKeys].every((key) => inputKeys.has(key))
-      ) {
-        const end = performance.now();
-        if (this._options.debug) {
-          console.log(`metadataResolver (cached): ${end - start}ms`);
-        }
-        return this._cachedMetadata;
+    // Asset metadata (decimals, name, ...) is immutable per id, so any entry we
+    // already hold is reusable forever. Only resolve the ids we're missing.
+    const missingIds = normalizedIds.filter(
+      (id) => !this._cachedMetadata.has(id),
+    );
+
+    if (missingIds.length === 0) {
+      const end = performance.now();
+      if (this._options.debug) {
+        console.log(`metadataResolver (cached): ${end - start}ms`);
       }
+      return this._cachedMetadata;
     }
 
     // Abort any in-flight metadata fetch
@@ -921,11 +928,11 @@ export class WalletObserver<
     const currentController = this._metadataAbortController;
 
     let attempts = 0;
-    let newMetadata: Map<string, AssetMetadata> | undefined;
-    while (attempts <= 3 && !newMetadata) {
+    let resolved: Map<string, AssetMetadata> | undefined;
+    while (attempts <= 3 && !resolved) {
       try {
-        newMetadata = await this._options.metadataResolver({
-          assetIds: assetIds.map(normalizeAssetIdWithDot),
+        resolved = await this._options.metadataResolver({
+          assetIds: missingIds,
           normalizeAssetId: normalizeAssetIdWithDot,
           isAdaAsset,
         });
@@ -934,14 +941,15 @@ export class WalletObserver<
       }
     }
 
-    // If this request was aborted while in-flight, return current cache (a new fetch is in progress)
+    // If this request was aborted while in-flight, a newer fetch is in progress;
+    // return the current cache and let that one win.
     if (currentController.signal.aborted) {
       return this._cachedMetadata;
     }
 
-    if (!newMetadata) {
-      newMetadata = await this.fallbackMetadataResolver({
-        assetIds: assetIds.map(normalizeAssetIdWithDot),
+    if (!resolved) {
+      resolved = await this.fallbackMetadataResolver({
+        assetIds: missingIds,
         normalizeAssetId: normalizeAssetIdWithDot,
         isAdaAsset,
       });
@@ -952,13 +960,17 @@ export class WalletObserver<
       return this._cachedMetadata;
     }
 
-    this._cachedMetadata = newMetadata;
+    // Merge freshly-resolved entries into the cache (don't replace it) so
+    // previously-resolved assets are preserved across balance changes.
+    for (const [id, metadata] of resolved) {
+      this._cachedMetadata.set(id, metadata);
+    }
 
     const end = performance.now();
     if (this._options.debug) {
       console.log(`metadataResolver: ${end - start}ms`);
     }
-    return newMetadata;
+    return this._cachedMetadata;
   };
 
   /**

--- a/lib/src/classes/__tests__/WalletObserver.test.ts
+++ b/lib/src/classes/__tests__/WalletObserver.test.ts
@@ -13,6 +13,7 @@ import {
   TMetadataResolverFunc,
   TWalletObserverOptions,
 } from "../../index.js";
+import { normalizeAssetIdWithDot } from "../../utils/assets.js";
 import * as getLibModules from "../../utils/getLibs.js";
 import { WalletObserver } from "../WalletObserver.class.js";
 
@@ -381,6 +382,69 @@ describe("WalletObserver", async () => {
         EWalletObserverEvents.DISCONNECT,
       );
       expect(spiedOnGetPeerConnect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("__metadataResolverWithCache()", () => {
+    // A policyId+assetName pair as it arrives from `data.multiasset().keys()`:
+    // dotless. The resolver stores its results under the dotted (normalized)
+    // form, so the cache must normalize before comparing or it never hits.
+    const dotlessA = `${"a".repeat(56)}414243`;
+    const dotlessB = `${"b".repeat(56)}444546`;
+
+    const makeCountingResolver = () => {
+      const batches: string[][] = [];
+      const resolver: TMetadataResolverFunc<IAssetAmountMetadata> = async ({
+        assetIds,
+        normalizeAssetId,
+      }) => {
+        batches.push(assetIds);
+        const map = new Map<string, IAssetAmountMetadata>();
+        assetIds.forEach((id) =>
+          map.set(normalizeAssetId(id), {
+            decimals: 6,
+            assetId: normalizeAssetId(id),
+          }),
+        );
+        return map;
+      };
+      return { batches, resolver };
+    };
+
+    it("hits the cache for a repeated multi-asset set (does not refetch)", async () => {
+      const { batches, resolver } = makeCountingResolver();
+      const observer = new WalletObserver({ metadataResolver: resolver });
+      const resolve = (observer as unknown as {
+        __metadataResolverWithCache: (ids: string[]) => Promise<unknown>;
+      }).__metadataResolverWithCache;
+
+      await resolve(["ada.lovelace", dotlessA]);
+      // Same set again: with dotless-vs-dotted key mismatch this used to miss
+      // every time. It must now short-circuit without calling the resolver.
+      await resolve(["ada.lovelace", dotlessA]);
+
+      expect(batches.length).toEqual(1);
+    });
+
+    it("only resolves ids it does not already hold, merging into the cache", async () => {
+      const { batches, resolver } = makeCountingResolver();
+      const observer = new WalletObserver({ metadataResolver: resolver });
+      const resolve = (observer as unknown as {
+        __metadataResolverWithCache: (
+          ids: string[],
+        ) => Promise<Map<string, IAssetAmountMetadata>>;
+      }).__metadataResolverWithCache;
+
+      await resolve(["ada.lovelace", dotlessA]);
+      const merged = await resolve(["ada.lovelace", dotlessA, dotlessB]);
+
+      // Second call fetches ONLY the newly-seen asset, not the whole set.
+      expect(batches.length).toEqual(2);
+      expect(batches[1]).toEqual([normalizeAssetIdWithDot(dotlessB)]);
+      // ...but the returned map still carries every requested asset.
+      expect(merged.has(normalizeAssetIdWithDot(dotlessA))).toBeTrue();
+      expect(merged.has(normalizeAssetIdWithDot(dotlessB))).toBeTrue();
+      expect(merged.has("ada.lovelace")).toBeTrue();
     });
   });
 

--- a/lib/src/classes/__tests__/WalletObserver.test.ts
+++ b/lib/src/classes/__tests__/WalletObserver.test.ts
@@ -414,9 +414,11 @@ describe("WalletObserver", async () => {
     it("hits the cache for a repeated multi-asset set (does not refetch)", async () => {
       const { batches, resolver } = makeCountingResolver();
       const observer = new WalletObserver({ metadataResolver: resolver });
-      const resolve = (observer as unknown as {
-        __metadataResolverWithCache: (ids: string[]) => Promise<unknown>;
-      }).__metadataResolverWithCache;
+      const resolve = (
+        observer as unknown as {
+          __metadataResolverWithCache: (ids: string[]) => Promise<unknown>;
+        }
+      ).__metadataResolverWithCache;
 
       await resolve(["ada.lovelace", dotlessA]);
       // Same set again: with dotless-vs-dotted key mismatch this used to miss
@@ -429,11 +431,13 @@ describe("WalletObserver", async () => {
     it("only resolves ids it does not already hold, merging into the cache", async () => {
       const { batches, resolver } = makeCountingResolver();
       const observer = new WalletObserver({ metadataResolver: resolver });
-      const resolve = (observer as unknown as {
-        __metadataResolverWithCache: (
-          ids: string[],
-        ) => Promise<Map<string, IAssetAmountMetadata>>;
-      }).__metadataResolverWithCache;
+      const resolve = (
+        observer as unknown as {
+          __metadataResolverWithCache: (
+            ids: string[],
+          ) => Promise<Map<string, IAssetAmountMetadata>>;
+        }
+      ).__metadataResolverWithCache;
 
       await resolve(["ada.lovelace", dotlessA]);
       const merged = await resolve(["ada.lovelace", dotlessA, dotlessB]);

--- a/lib/src/classes/__tests__/WalletObserver.test.ts
+++ b/lib/src/classes/__tests__/WalletObserver.test.ts
@@ -452,6 +452,21 @@ describe("WalletObserver", async () => {
     });
   });
 
+  describe("getUtxos()", () => {
+    it("returns the same parsed array reference when the CBOR is unchanged", async () => {
+      const observer = new WalletObserver();
+      await observer.connectWallet("eternl");
+
+      const first = await observer.getUtxos();
+      const second = await observer.getUtxos();
+
+      expect(first).toBeInstanceOf(Array);
+      // Referential equality is preserved across calls so unchanged UTxOs do
+      // not churn downstream React state / re-renders.
+      expect(first).toBe(second);
+    });
+  });
+
   describe("getCip45Instance()", () => {
     it("should properly get the instance", async () => {
       const observer = new WalletObserver({

--- a/lib/src/react-components/WalletObserverProvider/hooks/useWalletObserverState.ts
+++ b/lib/src/react-components/WalletObserverProvider/hooks/useWalletObserverState.ts
@@ -13,7 +13,10 @@ import { ReadOnlyApi } from "../../../classes/ReadOnlyApi.class.js";
 import { WalletBalanceMap } from "../../../classes/WalletBalanceMap.class.js";
 import { WalletObserver } from "../../../classes/WalletObserver.class.js";
 import { ADA_ASSET_ID } from "../../../constants.js";
-import { areAssetMapsEqual } from "../../../utils/comparisons.js";
+import {
+  areAssetMapsEqual,
+  areUtxoListsEqual,
+} from "../../../utils/comparisons.js";
 
 /**
  * Internal use only. The main action that sync WalletObserver api responses with
@@ -158,28 +161,22 @@ export const useWalletObserverState = <
 
           const newUtxos = freshData.utxos;
           if (newUtxos instanceof Array) {
-            setUtxos((prevValue) => {
-              const prevValueRep = prevValue?.map((v) => v.toCbor());
-              const newValueRep = newUtxos?.map((v) => v.toCbor());
-              if (prevValueRep !== newValueRep) {
-                return newUtxos;
-              }
-
-              return prevValue;
-            });
+            // Compare element-wise by CBOR. The previous check mapped both
+            // lists to fresh arrays and compared them by reference, which is
+            // ALWAYS unequal — so utxos state (and the memoized context value)
+            // was replaced on every sync, re-rendering every consumer.
+            setUtxos((prevValue) =>
+              areUtxoListsEqual(prevValue, newUtxos) ? prevValue : newUtxos,
+            );
           }
 
           const newCollateral = freshData.collateral;
           if (newCollateral instanceof Array) {
-            setCollateral((prevValue) => {
-              const prevValueRep = prevValue?.map((v) => v.toCbor());
-              const newValueRep = newCollateral?.map((v) => v.toCbor());
-              if (prevValueRep !== newValueRep) {
-                return newCollateral;
-              }
-
-              return prevValue;
-            });
+            setCollateral((prevValue) =>
+              areUtxoListsEqual(prevValue, newCollateral)
+                ? prevValue
+                : newCollateral,
+            );
           }
 
           const newFeeAddress = freshData.feeAddress;

--- a/lib/src/react-components/WalletObserverProvider/hooks/useWalletObserverState.ts
+++ b/lib/src/react-components/WalletObserverProvider/hooks/useWalletObserverState.ts
@@ -117,18 +117,23 @@ export const useWalletObserverState = <
         startTransition(() => {
           const newBalanceMap = freshData.balanceMap;
           if (newBalanceMap instanceof WalletBalanceMap) {
+            // Commit the balance map unconditionally — the token list must
+            // surface even when ADA is momentarily absent or zero. Previously
+            // both updates were gated on a truthy ADA AssetAmount, so any sync
+            // that failed to resolve ADA stranded the entire balance (and the
+            // token UI that derives from it).
+            setBalance((prevBalance) =>
+              areAssetMapsEqual(prevBalance, newBalanceMap)
+                ? prevBalance
+                : newBalanceMap,
+            );
+
             const newAdaBalance = newBalanceMap.get(ADA_ASSET_ID);
             if (newAdaBalance) {
               setAdaBalance((prevBalance) =>
                 prevBalance.amount === newAdaBalance.amount
                   ? prevBalance
                   : newAdaBalance,
-              );
-
-              setBalance((prevBalance) =>
-                areAssetMapsEqual(prevBalance, newBalanceMap)
-                  ? prevBalance
-                  : newBalanceMap,
               );
             }
           }

--- a/lib/src/utils/comparisons.ts
+++ b/lib/src/utils/comparisons.ts
@@ -1,3 +1,5 @@
+import type { TransactionUnspentOutput } from "@cardano-sdk/core/dist/cjs/Serialization/index.js";
+
 import { WalletBalanceMap } from "../classes/WalletBalanceMap.class.js";
 
 /**
@@ -62,4 +64,29 @@ export const areAssetMapsEqual = (
   }
 
   return true;
+};
+
+/**
+ * Compares two lists of UTxOs by their serialized CBOR. Returns true when both
+ * lists hold the same outputs in the same order (or are the same reference).
+ * Used to preserve referential equality of utxos/collateral state across syncs
+ * so unchanged data does not trigger downstream re-renders.
+ *
+ * @param {TransactionUnspentOutput[]} [a] - The first list of UTxOs.
+ * @param {TransactionUnspentOutput[]} [b] - The second list of UTxOs.
+ * @returns {boolean}
+ */
+export const areUtxoListsEqual = (
+  a?: TransactionUnspentOutput[],
+  b?: TransactionUnspentOutput[],
+): boolean => {
+  if (a === b) {
+    return true;
+  }
+
+  if (!a || !b || a.length !== b.length) {
+    return false;
+  }
+
+  return a.every((output, i) => output.toCbor() === b[i].toCbor());
 };


### PR DESCRIPTION
## Why

These changes came out of investigating a report of the SundaeSwap DEX showing **`Avail. Balance 0`** with a **perpetually-loading "Your Tokens" list**. That symptom turned out to be a **Blockfrost misconfiguration in the connected wallet** (no API key injected) — *not* a wallet-lite bug. But the dig surfaced three independent defects in the observer worth fixing on their own merits, batched here. They're graded honestly by real-world impact below.

## What

### 1. utxos/collateral no longer re-render every sync — *the impactful one*
The equality check mapped both the previous and next lists to fresh `toCbor()` arrays and compared them **by reference** — always unequal — so `utxos`/`collateral` state got a new identity on every sync. That changed the memoized context value, **re-rendering every wallet-data consumer on each `refreshInterval`** (5 s in dex-v2), whether or not anything actually changed. Now compared element-wise by CBOR (`areUtxoListsEqual`), backed by a CBOR-level cache in `getUtxos`/`getCollateral` that returns the *same parsed array* when the raw CBOR is unchanged — stable reference + no redundant deserialization, mirroring the existing `getBalance`/`getUsedAddresses` caches.

### 2. Metadata cache actually caches now — *real, but modest*
The cache-hit check compared the *raw* requested ids (dotless, from `data.multiasset().keys()`) against the *normalized* cached keys (dotted), so it **never hit for any wallet holding a native asset** — dead code. Fixed by normalizing once up front and switching to an **incremental, merge-don't-replace** cache that resolves only the ids it's missing. Impact is bounded: `getBalanceMap` already short-circuits on unchanged balance CBOR, so the redundant refetch happened on every *balance change* (not every sync) — but for a multi-asset wallet that's a full metadata round-trip where resolving one new token would do.

### 3. Balance map commits even when ADA is absent — *defensive*
`syncWallet` gated *both* `setAdaBalance` and `setBalance` behind `if (newAdaBalance)`. In practice `getBalanceMap` always sets ADA (even `0n` is a truthy `AssetAmount`), so this gate effectively never blocks today — this is a defensive/clarity change, not a fix for an observed failure. The balance map now commits unconditionally; ADA still commits only when present.

## Test plan

- [x] `bun test` — 48 pass / 0 fail
- [x] Regression: a repeated multi-asset set hits the metadata cache with no resolver call; a newly-seen asset resolves **only** that id (both fail on the old dotless-vs-dotted comparison)
- [x] Regression: `getUtxos` returns the same array reference when the CBOR is unchanged
- [ ] Manual: confirm wallet-data consumers stop re-rendering on every refresh interval, and a multi-asset wallet no longer refetches full metadata on balance change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
